### PR TITLE
fix: remove redundant blank lines in CsvItemExporter generated csv

### DIFF
--- a/blockchainetl_common/exporters.py
+++ b/blockchainetl_common/exporters.py
@@ -107,7 +107,8 @@ class CsvItemExporter(BaseItemExporter):
             file,
             line_buffering=False,
             write_through=True,
-            encoding=self.encoding
+            encoding=self.encoding,
+            newline=''
         ) if six.PY3 else file
         self.csv_writer = csv.writer(self.stream, **kwargs)
         self._headers_not_written = True


### PR DESCRIPTION
Reference:
https://stackoverflow.com/questions/3348460/csv-file-written-with-python-has-blank-lines-between-each-row